### PR TITLE
[ISSUE-5] fix: alinear IDs de test cases con TEST_CASES.md y corregir API-034

### DIFF
--- a/src/test/java/features/activities/manage_activities.feature
+++ b/src/test/java/features/activities/manage_activities.feature
@@ -1,8 +1,8 @@
 @activities @put
 Feature: Gestionar actividades — PUT /api/courses/{courseId}/activities
-  Valida configuración de actividades: happy path, suma != 100, nombre vacío,
-  duplicados, porcentaje 0, actualización y verificación en detalle.
-  HU: HDU_7 | Test Cases: API-023, API-024, API-025, API-026, API-027, API-028, API-029
+  Valida configuración de actividades: programa válido, suma ≠ 100, nombre vacío,
+  duplicados, ponderación ≤ 0, actualización de ponderación y eliminación con redistribución.
+  HU: HDU_11, HDU_12, HDU_13 | Test Cases: API-023, API-024, API-025, API-026, API-027, API-028, API-029
 
   Background:
     * url baseUrl
@@ -26,18 +26,7 @@ Feature: Gestionar actividades — PUT /api/courses/{courseId}/activities
     * def courseId = response.id
 
   @smoke @happy-path @API-023
-  Scenario: API-023 — Configurar 2 actividades (suma 100%)
-    * def payload = read('classpath:testdata/activities/activities_valid_two.json')
-    Given path '/api/courses', courseId, 'activities'
-    And header X-Session-Token = token
-    And request payload
-    When method put
-    Then status 200
-    And match response.activities == '#[2]'
-    And match each response.activities == { id: '#uuid', name: '#string', percentage: '#number' }
-
-  @happy-path @API-024
-  Scenario: API-024 — Configurar 3 actividades (suma 100%)
+  Scenario: API-023 — Definir programa válido (suma = 100 %)
     * def payload = read('classpath:testdata/activities/activities_valid_three.json')
     Given path '/api/courses', courseId, 'activities'
     And header X-Session-Token = token
@@ -45,9 +34,10 @@ Feature: Gestionar actividades — PUT /api/courses/{courseId}/activities
     When method put
     Then status 200
     And match response.activities == '#[3]'
+    And match each response.activities == { id: '#uuid', name: '#string', percentage: '#number' }
 
-  @error-path @API-025
-  Scenario: API-025 — Actividades con suma != 100%
+  @error-path @API-024
+  Scenario: API-024 — Definir programa con suma ≠ 100 %
     * def payload = read('classpath:testdata/activities/activities_sum_not_100.json')
     Given path '/api/courses', courseId, 'activities'
     And header X-Session-Token = token
@@ -56,8 +46,8 @@ Feature: Gestionar actividades — PUT /api/courses/{courseId}/activities
     Then status 400
     And match response.message == 'La suma de ponderaciones debe ser exactamente 100%'
 
-  @error-path @HALLAZGO-6 @API-026
-  Scenario: API-026 — Actividad con nombre vacío
+  @error-path @HALLAZGO-6 @API-025
+  Scenario: API-025 — Definir programa con nombre de instancia vacío
     # HALLAZGO-6: PUT /activities no tiene @Valid, podría aceptar nombre vacío
     * def payload = read('classpath:testdata/activities/activities_empty_name.json')
     Given path '/api/courses', courseId, 'activities'
@@ -66,8 +56,8 @@ Feature: Gestionar actividades — PUT /api/courses/{courseId}/activities
     When method put
     Then status 400
 
-  @error-path @API-027
-  Scenario: API-027 — Actividades con nombres duplicados
+  @error-path @API-026
+  Scenario: API-026 — Definir programa con nombres de instancias duplicados
     * def payload = read('classpath:testdata/activities/activities_duplicate_names.json')
     Given path '/api/courses', courseId, 'activities'
     And header X-Session-Token = token
@@ -76,8 +66,8 @@ Feature: Gestionar actividades — PUT /api/courses/{courseId}/activities
     Then status 400
     And match response.message == 'Las actividades no pueden tener nombres duplicados'
 
-  @error-path @API-028
-  Scenario: API-028 — Actividad con porcentaje 0
+  @error-path @API-027
+  Scenario: API-027 — Definir programa con ponderación ≤ 0
     * def payload = read('classpath:testdata/activities/activities_zero_percentage.json')
     Given path '/api/courses', courseId, 'activities'
     And header X-Session-Token = token
@@ -86,10 +76,10 @@ Feature: Gestionar actividades — PUT /api/courses/{courseId}/activities
     Then status 400
     And match response.message == 'Cada actividad debe tener una ponderacion mayor a 0'
 
-  @happy-path @API-029
-  Scenario: API-029 — Actualizar actividades y verificar reflejo en detalle
-    # Primera configuración
-    * def payload = read('classpath:testdata/activities/activities_valid_two.json')
+  @happy-path @API-028
+  Scenario: API-028 — Actualizar ponderación de instancias existentes (suma = 100 %)
+    # Primera configuración: 3 actividades (30 + 30 + 40)
+    * def payload = read('classpath:testdata/activities/activities_valid_three.json')
     Given path '/api/courses', courseId, 'activities'
     And header X-Session-Token = token
     And request payload
@@ -97,19 +87,41 @@ Feature: Gestionar actividades — PUT /api/courses/{courseId}/activities
     Then status 200
     * def act1Id = response.activities[0].id
     * def act2Id = response.activities[1].id
-    # Actualizar con nuevos pesos usando IDs reales
-    * def updated = [{id: '#(act1Id)', name: 'Examen Final', percentage: 30.0}, {id: '#(act2Id)', name: 'Tarea', percentage: 70.0}]
+    * def act3Id = response.activities[2].id
+    # Actualizar ponderaciones: P1 (20%), P2 (40%), Final (40%)
+    * def updated = [{id: '#(act1Id)', name: 'Parcial 1', percentage: 20.0}, {id: '#(act2Id)', name: 'Parcial 2', percentage: 40.0}, {id: '#(act3Id)', name: 'Examen Final', percentage: 40.0}]
     Given path '/api/courses', courseId, 'activities'
     And header X-Session-Token = token
     And request updated
     When method put
     Then status 200
-    And match response.activities == '#[2]'
-    # Verificar en detalle del curso
+    And match response.activities == '#[3]'
+    # Verificar ponderaciones en detalle del curso
     Given path '/api/courses', courseId
     And header X-Session-Token = token
     When method get
     Then status 200
+    And match response.activities[0].percentage == 20
+    And match response.activities[1].percentage == 40
+    And match response.activities[2].percentage == 40
+
+  @happy-path @API-029
+  Scenario: API-029 — Eliminar instancia con redistribución válida (suma = 100 %)
+    # Configurar 3 actividades (30 + 30 + 40)
+    * def payload = read('classpath:testdata/activities/activities_valid_three.json')
+    Given path '/api/courses', courseId, 'activities'
+    And header X-Session-Token = token
+    And request payload
+    When method put
+    Then status 200
+    * def act1Id = response.activities[0].id
+    * def act3Id = response.activities[2].id
+    # Eliminar Parcial 2, redistribuir: P1 (40%) + Final (60%)
+    * def reduced = [{id: '#(act1Id)', name: 'Parcial 1', percentage: 40.0}, {id: '#(act3Id)', name: 'Examen Final', percentage: 60.0}]
+    Given path '/api/courses', courseId, 'activities'
+    And header X-Session-Token = token
+    And request reduced
+    When method put
+    Then status 200
     And match response.activities == '#[2]'
-    And match response.activities[0].percentage == 30
-    And match response.activities[1].percentage == 70
+    And match response.activities[*].name !contains 'Parcial 2'

--- a/src/test/java/features/courses/create_course.feature
+++ b/src/test/java/features/courses/create_course.feature
@@ -1,6 +1,6 @@
 @courses @post
 Feature: Crear curso — POST /api/courses
-  Valida creación de cursos: happy path, nombre vacío y nombre duplicado.
+  Valida creación de cursos: happy path, título duplicado y título vacío.
   HU: HDU_3 | Test Cases: API-012, API-013, API-014
 
   Background:
@@ -37,17 +37,7 @@ Feature: Crear curso — POST /api/courses
     And match response[*].name contains courseName
 
   @error-path @API-013
-  Scenario: API-013 — Crear curso con nombre vacío
-    * def payload = read('classpath:testdata/courses/create_course_empty_name.json')
-    Given path '/api/courses'
-    And header X-Session-Token = token
-    And request payload
-    When method post
-    Then status 400
-    And match response.message == 'Solicitud invalida'
-
-  @error-path @API-014
-  Scenario: API-014 — Crear curso con nombre duplicado (mismo docente)
+  Scenario: API-013 — Crear curso con título duplicado (mismo docente)
     * def courseName = 'DupCurso_' + java.lang.System.currentTimeMillis()
     * def payload = read('classpath:testdata/courses/create_course_valid.json')
     * set payload.name = courseName
@@ -66,3 +56,13 @@ Feature: Crear curso — POST /api/courses
     When method post
     Then status 409
     And match response.message == 'Ya existe un curso con este nombre'
+
+  @error-path @API-014
+  Scenario: API-014 — Crear curso con título vacío
+    * def payload = read('classpath:testdata/courses/create_course_empty_name.json')
+    Given path '/api/courses'
+    And header X-Session-Token = token
+    And request payload
+    When method post
+    Then status 400
+    And match response.message == 'Solicitud invalida'

--- a/src/test/java/features/courses/get_course_detail.feature
+++ b/src/test/java/features/courses/get_course_detail.feature
@@ -1,7 +1,7 @@
 @courses @get
 Feature: Detalle del curso — GET /api/courses/{courseId}
   Valida obtención de detalle de un curso existente y uno inexistente.
-  HU: HDU_3 | Test Cases: API-015, API-016
+  HU: HDU_4 | Test Cases: API-015, API-016
 
   Background:
     * url baseUrl

--- a/src/test/java/features/grades/manage_grades.feature
+++ b/src/test/java/features/grades/manage_grades.feature
@@ -1,7 +1,8 @@
 @grades @put
 Feature: Registrar calificaciones — PUT /api/courses/{courseId}/grades
-  Valida registro de notas: happy path, nota negativa, valor no numérico, nota null y sin actividades.
-  HU: HDU_9 | Test Cases: API-030, API-031, API-032, API-033, API-034
+  Valida registro de notas: happy path, nota negativa, valor no numérico, nota nula
+  y recálculo de promedios tras cambio de ponderaciones.
+  HU: HDU_14 | Test Cases: API-030, API-031, API-032, API-033, API-034
 
   Background:
     * url baseUrl
@@ -37,7 +38,7 @@ Feature: Registrar calificaciones — PUT /api/courses/{courseId}/grades
     When method post
     Then status 200
     # Configurar actividades
-    * def actPayload = read('classpath:testdata/activities/activities_valid_two.json')
+    * def actPayload = read('classpath:testdata/activities/activities_valid_three.json')
     Given path '/api/courses', courseId, 'activities'
     And header X-Session-Token = token
     And request actPayload
@@ -45,6 +46,7 @@ Feature: Registrar calificaciones — PUT /api/courses/{courseId}/grades
     Then status 200
     * def activityId1 = response.activities[0].id
     * def activityId2 = response.activities[1].id
+    * def activityId3 = response.activities[2].id
 
   @smoke @happy-path @API-030
   Scenario: API-030 — Registrar calificación válida (0–5)
@@ -73,7 +75,7 @@ Feature: Registrar calificaciones — PUT /api/courses/{courseId}/grades
     Then status 400
     And match response.message == 'La nota no puede ser negativa'
 
-  @error-path @HALLAZGO-3 @API-032
+  @error-path @bug @HALLAZGO-3 @API-032
   Scenario: API-032 — Registrar calificación con valor no numérico
     # HALLAZGO-3: Enviar String en campo Double causa 500 en vez de 400
     * def gradePayload = read('classpath:testdata/grades/grade_non_numeric.json')
@@ -97,33 +99,44 @@ Feature: Registrar calificaciones — PUT /api/courses/{courseId}/grades
     When method put
     Then status 200
 
-  @error-path @API-034
-  Scenario: API-034 — Registrar calificación sin actividades configuradas
-    # Crear curso SIN actividades
-    * def coursePayload2 = read('classpath:testdata/courses/create_course_valid.json')
-    * set coursePayload2.name = 'NoActCurso_' + java.lang.System.currentTimeMillis()
-    Given path '/api/courses'
+  @happy-path @API-034
+  Scenario: API-034 — Recálculo de promedios tras cambio de ponderaciones
+    # Background ya configuró: Parcial 1 (30%), Parcial 2 (30%), Examen Final (40%)
+    * def p1Id = activityId1
+    * def p2Id = activityId2
+    * def finalId = activityId3
+    # Paso 1: Asignar notas — P1=4.0, P2=3.0, Final=5.0
+    * def g1 = {studentId: '#(studentIdentifier)', activityId: '#(p1Id)', grade: 4.0}
+    Given path '/api/courses', courseId, 'grades'
     And header X-Session-Token = token
-    And request coursePayload2
-    When method post
-    Then status 201
-    * def courseIdNoAct = response.id
-    # Inscribir estudiante en ese curso
-    * def enrollPayload2 = read('classpath:testdata/students/enroll_student_valid.json')
-    * set enrollPayload2.studentId = 'STU_NOACT_' + java.lang.System.currentTimeMillis()
-    * set enrollPayload2.name = 'NoActStudent'
-    * set enrollPayload2.email = 'noact_' + java.lang.System.currentTimeMillis() + '@test.com'
-    Given path '/api/courses', courseIdNoAct, 'students'
-    And header X-Session-Token = token
-    And request enrollPayload2
-    When method post
-    Then status 200
-    # Intentar calificar sin actividades
-    * def gradePayload = read('classpath:testdata/grades/grade_valid.json')
-    * set gradePayload.studentId = enrollPayload2.studentId
-    * set gradePayload.activityId = '00000000-0000-0000-0000-000000000000'
-    Given path '/api/courses', courseIdNoAct, 'grades'
-    And header X-Session-Token = token
-    And request gradePayload
+    And request g1
     When method put
-    Then status 404
+    Then status 200
+    * def g2 = {studentId: '#(studentIdentifier)', activityId: '#(p2Id)', grade: 3.0}
+    Given path '/api/courses', courseId, 'grades'
+    And header X-Session-Token = token
+    And request g2
+    When method put
+    Then status 200
+    * def g3 = {studentId: '#(studentIdentifier)', activityId: '#(finalId)', grade: 5.0}
+    Given path '/api/courses', courseId, 'grades'
+    And header X-Session-Token = token
+    And request g3
+    When method put
+    Then status 200
+    # Promedio ponderado previo = 4.0×0.30 + 3.0×0.30 + 5.0×0.40 = 4.10
+    # Paso 2: Actualizar ponderaciones (P1: 20%, P2: 20%, Final: 60%)
+    * def updatedAct = [{id: '#(p1Id)', name: 'Parcial 1', percentage: 20.0}, {id: '#(p2Id)', name: 'Parcial 2', percentage: 20.0}, {id: '#(finalId)', name: 'Examen Final', percentage: 60.0}]
+    Given path '/api/courses', courseId, 'activities'
+    And header X-Session-Token = token
+    And request updatedAct
+    When method put
+    Then status 200
+    # Paso 3: Verificar que el promedio se recalculó
+    # Nuevo promedio ponderado = 4.0×0.20 + 3.0×0.20 + 5.0×0.60 = 4.40
+    Given path '/api/courses', courseId, 'students', studentIdentifier, 'report'
+    And param format = 'json'
+    And header X-Session-Token = token
+    When method get
+    Then status 200
+    And match response.weightedAverage == 4.4

--- a/src/test/java/features/reports/export_report.feature
+++ b/src/test/java/features/reports/export_report.feature
@@ -1,7 +1,6 @@
 @reports @get
 Feature: Reporte de notas — GET /api/courses/{courseId}/students/{studentId}/report
-  Valida exportación de reporte: happy path, sin calificaciones, estudiante no inscrito,
-  curso inexistente y estudiante inexistente.
+  Valida exportación de reporte: PDF, HTML, JSON, formato no soportado y notas vacías.
   HU: HDU_15 | Test Cases: API-035, API-036, API-037, API-038, API-039
 
   Background:
@@ -48,8 +47,8 @@ Feature: Reporte de notas — GET /api/courses/{courseId}/students/{studentId}/r
     * def activityId2 = response.activities[1].id
 
   @smoke @happy-path @API-035
-  Scenario: API-035 — Reporte con calificaciones completas
-    # Calificar actividad 1
+  Scenario: API-035 — Exportar boletín en formato PDF
+    # Calificar ambas actividades
     * def grade1 = read('classpath:testdata/grades/grade_valid.json')
     * set grade1.studentId = studentIdentifier
     * set grade1.activityId = activityId1
@@ -59,7 +58,6 @@ Feature: Reporte de notas — GET /api/courses/{courseId}/students/{studentId}/r
     And request grade1
     When method put
     Then status 200
-    # Calificar actividad 2
     * def grade2 = read('classpath:testdata/grades/grade_valid.json')
     * set grade2.studentId = studentIdentifier
     * set grade2.activityId = activityId2
@@ -69,7 +67,66 @@ Feature: Reporte de notas — GET /api/courses/{courseId}/students/{studentId}/r
     And request grade2
     When method put
     Then status 200
-    # Obtener reporte
+    # Exportar PDF
+    Given path '/api/courses', courseId, 'students', studentIdentifier, 'report'
+    And param format = 'pdf'
+    And header X-Session-Token = token
+    When method get
+    Then status 200
+    And match responseHeaders['Content-Type'][0] contains 'pdf'
+    And assert responseBytes.length > 0
+
+  @happy-path @API-036
+  Scenario: API-036 — Exportar boletín en formato HTML
+    # Calificar ambas actividades
+    * def grade1 = read('classpath:testdata/grades/grade_valid.json')
+    * set grade1.studentId = studentIdentifier
+    * set grade1.activityId = activityId1
+    * set grade1.grade = 4.5
+    Given path '/api/courses', courseId, 'grades'
+    And header X-Session-Token = token
+    And request grade1
+    When method put
+    Then status 200
+    * def grade2 = read('classpath:testdata/grades/grade_valid.json')
+    * set grade2.studentId = studentIdentifier
+    * set grade2.activityId = activityId2
+    * set grade2.grade = 3.8
+    Given path '/api/courses', courseId, 'grades'
+    And header X-Session-Token = token
+    And request grade2
+    When method put
+    Then status 200
+    # Exportar HTML
+    Given path '/api/courses', courseId, 'students', studentIdentifier, 'report'
+    And param format = 'html'
+    And header X-Session-Token = token
+    When method get
+    Then status 200
+    And match responseHeaders['Content-Type'][0] contains 'html'
+
+  @happy-path @API-037
+  Scenario: API-037 — Exportar boletín en formato JSON
+    # Calificar ambas actividades
+    * def grade1 = read('classpath:testdata/grades/grade_valid.json')
+    * set grade1.studentId = studentIdentifier
+    * set grade1.activityId = activityId1
+    * set grade1.grade = 4.5
+    Given path '/api/courses', courseId, 'grades'
+    And header X-Session-Token = token
+    And request grade1
+    When method put
+    Then status 200
+    * def grade2 = read('classpath:testdata/grades/grade_valid.json')
+    * set grade2.studentId = studentIdentifier
+    * set grade2.activityId = activityId2
+    * set grade2.grade = 3.8
+    Given path '/api/courses', courseId, 'grades'
+    And header X-Session-Token = token
+    And request grade2
+    When method put
+    Then status 200
+    # Exportar JSON
     Given path '/api/courses', courseId, 'students', studentIdentifier, 'report'
     And param format = 'json'
     And header X-Session-Token = token
@@ -81,46 +138,30 @@ Feature: Reporte de notas — GET /api/courses/{courseId}/students/{studentId}/r
     And match response.weightedAverage == '#number'
     And match response.generalAverage == '#number'
 
-  @happy-path @API-036
-  Scenario: API-036 — Reporte sin calificaciones (notas null o ausentes)
+  @error-path @API-038
+  Scenario: API-038 — Exportar boletín con formato no soportado
+    Given path '/api/courses', courseId, 'students', studentIdentifier, 'report'
+    And param format = 'xml'
+    And header X-Session-Token = token
+    When method get
+    Then status 400
+
+  @happy-path @API-039
+  Scenario: API-039 — Exportar boletín con notas vacías (advertencia)
+    # Calificar solo una actividad, dejar la otra sin nota
+    * def grade1 = read('classpath:testdata/grades/grade_valid.json')
+    * set grade1.studentId = studentIdentifier
+    * set grade1.activityId = activityId1
+    * set grade1.grade = 4.5
+    Given path '/api/courses', courseId, 'grades'
+    And header X-Session-Token = token
+    And request grade1
+    When method put
+    Then status 200
+    # Exportar JSON — debe indicar notas vacías
     Given path '/api/courses', courseId, 'students', studentIdentifier, 'report'
     And param format = 'json'
     And header X-Session-Token = token
     When method get
     Then status 200
-    And match response.student.id == studentIdentifier
-    And match response.course == '#string'
-
-  @error-path @API-037
-  Scenario: API-037 — Reporte para estudiante no inscrito en el curso
-    # Crear otro curso sin inscribir al estudiante
-    * def course2Payload = read('classpath:testdata/courses/create_course_valid.json')
-    * set course2Payload.name = 'NoInscrito_' + java.lang.System.currentTimeMillis()
-    Given path '/api/courses'
-    And header X-Session-Token = token
-    And request course2Payload
-    When method post
-    Then status 201
-    * def courseIdOther = response.id
-    # Intentar reporte de estudiante no inscrito en ese curso
-    Given path '/api/courses', courseIdOther, 'students', studentIdentifier, 'report'
-    And param format = 'json'
-    And header X-Session-Token = token
-    When method get
-    Then status 404
-
-  @error-path @API-038
-  Scenario: API-038 — Reporte con curso inexistente
-    Given path '/api/courses', '00000000-0000-0000-0000-000000000000', 'students', studentIdentifier, 'report'
-    And param format = 'json'
-    And header X-Session-Token = token
-    When method get
-    Then status 404
-
-  @error-path @API-039
-  Scenario: API-039 — Reporte con estudiante inexistente
-    Given path '/api/courses', courseId, 'students', 'NONEXISTENT_999', 'report'
-    And param format = 'json'
-    And header X-Session-Token = token
-    When method get
-    Then status 404
+    And match response.hasEmptyGrades == true

--- a/src/test/java/features/students/enroll_student.feature
+++ b/src/test/java/features/students/enroll_student.feature
@@ -1,6 +1,6 @@
 @students @post
 Feature: Inscribir estudiante — POST /api/courses/{courseId}/students
-  Valida inscripción: happy path, campos vacíos, email inválido y autocompletado.
+  Valida inscripción: happy path, campos vacíos, estudiante ya inscrito y autocompletado.
   HU: HDU_5 | Test Cases: API-019, API-020, API-021, API-022
 
   Background:
@@ -54,14 +54,24 @@ Feature: Inscribir estudiante — POST /api/courses/{courseId}/students
     And match response.message == 'Solicitud invalida'
 
   @error-path @API-021
-  Scenario: API-021 — Inscribir estudiante con email inválido
-    * def payload = read('classpath:testdata/students/enroll_student_invalid_email.json')
+  Scenario: API-021 — Inscribir estudiante ya inscrito en el curso
+    # Inscribir estudiante por primera vez
+    * def ts = java.lang.System.currentTimeMillis()
+    * def payload = read('classpath:testdata/students/enroll_student_valid.json')
+    * set payload.studentId = 'STU_DUP_' + ts
+    * set payload.name = 'Estudiante_Dup_' + ts
+    * set payload.email = 'dup_' + ts + '@test.com'
     Given path '/api/courses', courseId, 'students'
     And header X-Session-Token = token
     And request payload
     When method post
-    Then status 400
-    And match response.message == 'El correo electronico no es valido'
+    Then status 200
+    # Intentar inscripción duplicada en el mismo curso
+    Given path '/api/courses', courseId, 'students'
+    And header X-Session-Token = token
+    And request payload
+    When method post
+    Then status 409
 
   @happy-path @API-022
   Scenario: API-022 — Autocompletado: mismo studentId en otro curso reutiliza datos

--- a/src/test/java/testdata/activities/activities_valid_three.json
+++ b/src/test/java/testdata/activities/activities_valid_three.json
@@ -1,17 +1,17 @@
 [
   {
     "id": null,
+    "name": "Parcial 1",
+    "percentage": 30.0
+  },
+  {
+    "id": null,
+    "name": "Parcial 2",
+    "percentage": 30.0
+  },
+  {
+    "id": null,
     "name": "Examen Final",
     "percentage": 40.0
-  },
-  {
-    "id": null,
-    "name": "Tarea",
-    "percentage": 30.0
-  },
-  {
-    "id": null,
-    "name": "Proyecto",
-    "percentage": 30.0
   }
 ]


### PR DESCRIPTION
## Descripcion
Auditoria completa de los 40 test case IDs en los archivos \.feature\ contra \TEST_CASES.md\. Se encontraron IDs incorrectos, escenarios inventados y referencias de HU erroneas en 6 archivos. Este PR corrige todos los desajustes.

## Cambios incluidos

### create_course.feature
- API-013 y API-014 estaban intercambiados — corregidos: 013=titulo duplicado (409), 014=nombre vacio (400)

### get_course_detail.feature
- Referencia de HU corregida: HDU_3 → HDU_4

### enroll_student.feature
- API-021 tenia escenario inventado ('email invalido') — reemplazado por 'estudiante ya inscrito' (409 Conflict)

### manage_activities.feature
- HU corregida: HDU_7 → HDU_11, HDU_12, HDU_13
- 7 de 7 escenarios tenian IDs desajustados con escenarios inventados — reescritos completamente segun TEST_CASES.md

### manage_grades.feature
- HU corregida: HDU_9 → HDU_14
- Background migrado de 2 a 3 actividades (actividades_valid_three.json) — evita 500 al acumular sobre >100%
- API-034 reimplementado: asigna notas, actualiza ponderaciones 30/30/40→20/20/60, verifica weightedAverage==4.4

### export_report.feature
- 5 de 5 escenarios tenian IDs inventados — reescritos: API-035=PDF, API-036=HTML, API-037=JSON, API-038=xml-error(400), API-039=notas-vacias

### testdata/activities/activities_valid_three.json
- Actualizado: Parcial 1 (30%), Parcial 2 (30%), Examen Final (40%) alineado con TEST_CASES.md API-023

## Resultado de tests

\\\
Tests run: 85, Failures: 13, Errors: 0, Skipped: 0
\\\
- 72 tests pasan
- 13 fallan intencionalmente (HALLAZGO-1 x10, HALLAZGO-2 x1, HALLAZGO-3 x1, HALLAZGO-6 x1)

## Issue relacionado
Closes #5

## Checklist
- [x] .feature files alineados con TEST_CASES.md (40/40 IDs verificados)
- [x] Happy path (@smoke) y error path cubiertos
- [x] Datos de prueba sinteticos sin PII
- [x] baseUrl referenciada desde karate-config.js
- [x] Suite ejecuta correctamente: 72 pass, 13 fail esperados